### PR TITLE
Fix for Loan Anomaly

### DIFF
--- a/Assets/Scripts/Components/Views/Loans/CurrentLoanView.cs
+++ b/Assets/Scripts/Components/Views/Loans/CurrentLoanView.cs
@@ -19,13 +19,9 @@ public class CurrentLoanView : ViewBehaviour<LoanViewModel>
 		PayBackButton.Bind(ValueModel.New(new ButtonViewModel {
 			OnClick = Model.GUI_PayBackLoan
 		}));
-	}
-
-	protected override void Refresh(object sender, string propertyChanged) {
-		base.Refresh(sender, propertyChanged);
 
 		// this is null when you first pay back a loan and Model.Loan gets nulled out
-		if(Model.Loan != null) {
+		if (Model.Loan != null) {
 			Amount.Bind(ValueModel.New(Model.Loan.amount.ToString()));
 			Due.Bind(ValueModel.New(Model.Loan.numOfDaysUntilDue.ToString()));
 		}

--- a/Assets/Scripts/Components/Views/Loans/NewLoanView.cs
+++ b/Assets/Scripts/Components/Views/Loans/NewLoanView.cs
@@ -21,10 +21,6 @@ public class NewLoanView : ViewBehaviour<LoanViewModel>
 		TakeLoanButton.Bind(ValueModel.New(new ButtonViewModel {
 			OnClick = Model.GUI_TakeOutLoan
 		}));
-	}
-
-	protected override void Refresh(object sender, string propertyChanged) {
-		base.Refresh(sender, propertyChanged);
 
 		Amount.Bind(ValueModel.New(Model.NewLoan.amount.ToString()));
 		Due.Bind(ValueModel.New(Model.NewLoan.numOfDaysUntilDue.ToString()));


### PR DESCRIPTION
This change ensures that child views in the loan screen get bound before their refresh is called. I think the race condition was when the loan screen's refresh enabled the child view. That causes the child view's refresh to get called, but the child view's refresh called bind on its children (the StringViews which actually show the loan data), who could have been refreshed before the bind call and would have displayed default data.

I'm not 100% sure this fixes it, but I think it's likely.